### PR TITLE
Switch dotnet devcontainer to base version

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/dotnet
 {
   "name": "Sonarr",
-  "image": "mcr.microsoft.com/devcontainers/dotnet:1-10.0",
+  "image": "mcr.microsoft.com/devcontainers/dotnet:10.0",
   "features": {
     "ghcr.io/devcontainers/features/node:2": {
       "nodeGypDependencies": true,


### PR DESCRIPTION
#### Description

Based on https://mcr.microsoft.com/en-us/artifact/mar/devcontainers/dotnet/about#using_this_image would be better to use the base version instead of the semantic version if we always want to get the latest and not dealing with updates.